### PR TITLE
:sparkles: Adds `pip upgrade` support

### DIFF
--- a/src/pipfromrepl/__init__.py
+++ b/src/pipfromrepl/__init__.py
@@ -12,8 +12,16 @@ def user_install(module_name):
     subprocess.run([sys.executable, '-m', 'pip', 'install', '--user', module_name])
 
 
+def user_upgrade(module_name):
+    subprocess.run([sys.executable, '-m', 'pip', 'install', '--user', "--upgrade", module_name])
+
+
 def install(module_name):
     subprocess.run([sys.executable, '-m', 'pip', 'install', module_name])
+
+
+def upgrade(module_name):
+    subprocess.run([sys.executable, '-m', 'pip', 'install', "--upgrade", module_name])
 
 
 def uninstall(module_name, confirm=False):
@@ -48,8 +56,16 @@ def user_install3(module_name):
     subprocess.run([sys.executable, '-m', 'pip3', 'install', '--user', module_name])
 
 
+def user_upgrade3(module_name):
+    subprocess.run([sys.executable, '-m', 'pip3', 'install', '--user', "--upgrade", module_name])
+
+
 def install3(module_name):
     subprocess.run([sys.executable, '-m', 'pip3', 'install', module_name])
+
+
+def upgrade3(module_name):
+    subprocess.run([sys.executable, '-m', 'pip3', 'install', "--upgrade", module_name])
 
 
 def uninstall3(module_name, confirm=False):


### PR DESCRIPTION
Passing this along in case it's useful. 

This PR adds pip upgrade support via the following methods:

- `user_upgrade(module_name)`
- `upgrade(module_name)`
- ~`user_upgrade3(module_name)`~ (removed)
- ~`upgrade3(module_name)`~ (removed) 
